### PR TITLE
[v-play] remove Component.onCompleted in PositionSource

### DIFF
--- a/qml/harbour-berlin-vegan.qml
+++ b/qml/harbour-berlin-vegan.qml
@@ -76,11 +76,6 @@ ApplicationWindow
                 oldPosition.longitude = position.coordinate.longitude
             }
         }
-
-        Component.onCompleted: {
-            oldPosition.latitude  = position.coordinate.latitude
-            oldPosition.longitude = position.coordinate.longitude
-        }
     }
 
     JsonDownloadHelper {


### PR DESCRIPTION
For some reason that I cannot explain the list sorting works only on
iOS, if this source code is removed.

Ref #48