### PR TITLE
Add theme implementation

### DIFF
--- a/qml/Sailfish/Silica/ApplicationWindow.qml
+++ b/qml/Sailfish/Silica/ApplicationWindow.qml
@@ -1,6 +1,12 @@
 import VPlayApps 1.0
 
+import QtQuick 2.7
+
+import "." as SilicaComponents
+
 App {
+
+    id: app
 
     property var initialPage
     property var cover
@@ -8,6 +14,11 @@ App {
     NavigationStack {
         id: navigationStack
         initialPage: app.initialPage
+    }
+
+    Component.onCompleted: {
+        // We need to access the dp() function from the Theme component
+        SilicaComponents.Theme.myApp = app
     }
 
 }

--- a/qml/Sailfish/Silica/Label.qml
+++ b/qml/Sailfish/Silica/Label.qml
@@ -4,6 +4,4 @@ Label {
 
     property var truncationMode
 
-    visible: false
-
 }

--- a/qml/Sailfish/Silica/ListItem.qml
+++ b/qml/Sailfish/Silica/ListItem.qml
@@ -5,8 +5,12 @@ SimpleRow {
     signal clicked(int index)
 
     property var contentWidth
+    property var contentHeight
 
-    text: namelabel.text
-    detailText: "%1 %2".arg(streetLabel.text).arg(distance.text)
+    height: contentHeight
+
+    // HACK: Display arrow on the bottom right
+    text: " "
+    detailText: " "
 
 }

--- a/qml/Sailfish/Silica/Theme.qml
+++ b/qml/Sailfish/Silica/Theme.qml
@@ -1,0 +1,24 @@
+pragma Singleton
+
+import QtQuick 2.7
+
+import VPlayApps 1.0
+
+QtObject {
+
+    function dp(x) {
+        return myApp ? myApp.dp(x) : 0
+    }
+
+    property var myApp
+
+    property color primaryColor: Theme.textColor
+    property color secondaryColor: Theme.secondaryTextColor
+
+    property int fontSizeMedium: dp(Theme.listItem.fontSizeText)
+    property int fontSizeExtraSmall: dp(Theme.listItem.fontSizeDetailText)
+
+    property int paddingSmall: dp(10)
+    property int horizontalPageMargin: dp(15)
+
+}

--- a/qml/Sailfish/Silica/qmldir
+++ b/qml/Sailfish/Silica/qmldir
@@ -12,4 +12,5 @@ PageHeader 1.0 PageHeader.qml
 PullDownMenu 1.0 PullDownMenu.qml
 SearchField 1.0 SearchField.qml
 SilicaListView 1.0 SilicaListView.qml
+singleton Theme 1.0 Theme.qml
 VerticalScrollDecorator 1.0 VerticalScrollDecorator.qml


### PR DESCRIPTION
With this patch we show the content of the list delegate directly,
instead of accessing the IDs from inside the module. Therefore we set
the label component to be visible again, remove the texts from the
simple row and add our own Theme implementation.

Closes #56