### PR TITLE
[v-play] Provide a pushAttached() implementation

### DIFF
--- a/qml/components-v-play/MenuItem.qml
+++ b/qml/components-v-play/MenuItem.qml
@@ -6,6 +6,32 @@ NavigationItem {
     property var pageToVisit
     property alias text: item.title
     NavigationStack {
+        id: stack
         initialPage: pageToVisit
+
+        navigationBar.rightBarItem: IconButtonBarItem {
+            id: attachedButton
+
+            property var attachedPage
+            property var props
+            property var attachedTo
+
+            visible: attachedPage !== undefined
+                     && attachedTo === stack.currentPage
+            onClicked: {
+                if (visible)
+                {
+                    stack.push(attachedPage, props)
+                }
+            }
+        }
+
+        function pushAttached(page, props, icon)
+        {
+            attachedButton.attachedTo = stack.currentPage
+            attachedButton.attachedPage = page
+            attachedButton.props = props
+            attachedButton.icon  = icon
+        }
     }
 }

--- a/qml/components-v-play/Theme.qml
+++ b/qml/components-v-play/Theme.qml
@@ -19,6 +19,8 @@ QtObject {
             return IconType.list
         case "about":
             return IconType.questioncircle
+        case "mapmarker":
+            return IconType.mapmarker
         }
     }
 

--- a/qml/components-v-play/Theme.qml
+++ b/qml/components-v-play/Theme.qml
@@ -19,8 +19,8 @@ QtObject {
             return IconType.list
         case "about":
             return IconType.questioncircle
-        case "mapmarker":
-            return IconType.mapmarker
+        case "locationarrow":
+            return IconType.locationarrow
         }
     }
 

--- a/qml/pages/VenueList.qml
+++ b/qml/pages/VenueList.qml
@@ -156,7 +156,7 @@ BVApp.Page {
                                                                              currRestaurant.longCoord),
                                    positionSource: page.positionSource,
                                    name: currRestaurant.name
-                               }, BVApp.Theme.iconBy("mapmarker")
+                               }, BVApp.Theme.iconBy("locationarrow")
                                );
             }
         }

--- a/qml/pages/VenueList.qml
+++ b/qml/pages/VenueList.qml
@@ -149,27 +149,16 @@ BVApp.Page {
                                    positionSource : page.positionSource
                                });
 
-                // v-play: TypeError: Property 'pushAttached' of object NavigationStack_QMLTYPE_59(0x7f9f0cb5ba90, "_NavigationStack") is not a function
-                var mapPage = pageStack.pushAttached(Qt.resolvedUrl("VenueMapPage.qml"),
+                // The icon parameter is only used on v-play
+                pageStack.pushAttached(Qt.resolvedUrl("VenueMapPage.qml"),
                                {
                                    venueCoordinate: QtPositioning.coordinate(currRestaurant.latCoord,
                                                                              currRestaurant.longCoord),
                                    positionSource: page.positionSource,
                                    name: currRestaurant.name
-                               });
-
-                // TODO: Directly assigning a coordinate property to Map.center seems to be broken
-                // with the current Qt version (5.2)
-                mapPage.map.addMapItem(mapPage.venueMarker)
-                mapPage.map.addMapItem(mapPage.currentPosition)
-
-                mapPage.setMapCenter(mapPage.venueMarker.coordinate)
-
-                // Seems to be broken with the current version of Qt :/
-                mapPage.map.fitViewportToMapItems()
+                               }, BVApp.Theme.iconBy("mapmarker")
+                               );
             }
-
-
         }
         VerticalScrollDecorator {}
     }

--- a/qml/pages/VenueMapPage.qml
+++ b/qml/pages/VenueMapPage.qml
@@ -11,17 +11,8 @@ BVApp.Page {
 
     property var venueCoordinate
     property var positionSource
-    property string name
+    property alias name : page.title
     property alias map : map
-
-    // TODO: Directly assigning a coordinate property to Map.center seems to be broken
-    // with the current Qt version (5.2)
-    function setMapCenter(mapCenter)
-    {
-        map.center = mapCenter
-        map.update()
-
-    }
 
     PageHeader {
         id: header
@@ -97,6 +88,11 @@ BVApp.Page {
             enabled: true
         }
 
+        Component.onCompleted: {
+            addMapItem(venueMarker)
+            addMapItem(currentPosition)
+            center = venueCoordinate
+        }
 
         zoomLevel: maximumZoomLevel - 1
     }


### PR DESCRIPTION
The pushAttached feature of the Sailfish pageStack
(which we use to put the map for one venue on the
right hand side of the VenueDescription page)
is not available on v-play.

A navigation paradigm like this (where the currently shown
page isn't the top of the navigation stack) is also very
uncommon on iOS and Android. We therefore extented the
pushAttached() interface by one parameter: An icon that
is shown on the right side of the navigation bar (where
you would have an 'arrow to the right' symbol if you
transferred the Sailfish style navigation scheme strictly),
which you can use to then actually call the attached-pushed
page.

In contrast to Sailfish, we do not actually push the page
when pushAttached() is being called. Instead the page is
only being pushed lazily once you hit the button. We needed
to adapt the way we supply the VenueMapPage with its
information for that purpose (which definitely can be
considered a code cleanup anyway).

Note: Like the AboutPage the VenueMapPage too is
in an unpolished state on v-play.

// Github issue #66