### PR TITLE
fix location marker

### DIFF
--- a/qml/components-v-play/IconButton.qml
+++ b/qml/components-v-play/IconButton.qml
@@ -5,8 +5,11 @@ import "." as BVApp
 
 IconButton {
 
+    id: iconButton
+
     property string type
     property string icon
+    property string color
     property real scale
     property real size
 
@@ -19,7 +22,7 @@ IconButton {
         width: parent.width
 
         text: icon
-        color: BVApp.Theme.highlightDimmerColor
+        color: iconButton.color ? iconButton.color : BVApp.Theme.highlightDimmerColor
 
         font.family: "Material Icons"
         font.pixelSize: size

--- a/qml/components-v-play/Theme.qml
+++ b/qml/components-v-play/Theme.qml
@@ -17,7 +17,7 @@ QtObject {
             return "public"
         case "location":
         case "cover-location":
-            return IconType.mapmarker
+            return "location_on"
         case "food":
             return "restaurant_menu"
         case "shopping":


### PR DESCRIPTION
With the V-Play 2.12.x update "IconType.mapmarker" is gone. Just let's
rely on the Material Icon font directly.