### PR TITLE
[v-play] fix map marker not pointing to correct position

### DIFF
--- a/qml/components-v-play/IconButton.qml
+++ b/qml/components-v-play/IconButton.qml
@@ -19,18 +19,20 @@ IconButton {
 
     AppText {
         id: icn
-        width: parent.width
+        anchors.fill: parent
 
         text: icon
         color: iconButton.color ? iconButton.color : BVApp.Theme.highlightDimmerColor
 
         font.family: "Material Icons"
         font.pixelSize: size
+        horizontalAlignment: Text.AlignHCenter
     }
 
     Component.onCompleted: {
-        if (Layout.alignment) {
-            icn.horizontalAlignment = Layout.alignment
+        // HACK: if we are not the IconToolBar, we are the VenueMapPage
+        if (!Layout.alignment) {
+            icn.verticalAlignment = Text.AlignBottom
         }
     }
 }

--- a/qml/pages/VenueMapPage.qml
+++ b/qml/pages/VenueMapPage.qml
@@ -63,7 +63,7 @@ BVApp.Page {
         coordinate: positionSource.position.coordinate
 
         anchorPoint.x: currentPosImage.width / 2
-        anchorPoint.y: currentPosImage.height / 2
+        anchorPoint.y: currentPosImage.height
 
         sourceItem: BVApp.IconButton {
             id: currentPosImage


### PR DESCRIPTION
When zooming in and out one can see, that the map marker icon does not
point to the correct position all the time. This is because, there is an
invisible rectangle around the icon that needs to be taken into
account.

With this patch we center the icon horizontally and align it to the
bottom in the parent. Additionally we set the anchor point when zooming
to that exact point.

The 'anchors.fill: parent' also fixes the icons in the IconToolBar:
there weren't vertically centered, but only horizontally.

Closes #88