### PR TITLE
[Option 2] Replace opaque rectangle covering the street

### DIFF
--- a/qml/components-generic/VenueDescriptionHeader.qml
+++ b/qml/components-generic/VenueDescriptionHeader.qml
@@ -51,12 +51,19 @@ Item {
 
         fillMode: Image.PreserveAspectCrop
 
-        height: Math.max(parent.height - shrinkHeightBy,0)
+        height: Math.max(parent.height - streetLabel.height * 0.1 - shrinkHeightBy,0)
         width: parent.width
 
         // This eads to the effect that the image is being cropped
         // from both bottom and top by half a pixel per shrinkHeightBy
         y: shrinkHeightBy
+    }
+
+    OpacityRampEffect {
+        anchors.fill: image
+        id: ramp
+        sourceItem: image
+        direction: BVApp.Theme.opacityRampTopToBottom
     }
 
     Rectangle {
@@ -81,36 +88,19 @@ Item {
         y: initalY + shrinkHeightBy * 0.5
     }
 
-    Rectangle {
-        anchors {
-            top: streetLabel.top
-            topMargin: -BVApp.Theme.paddingMedium
-            left: image.left
-            right: image.right
-            bottom: image.bottom
-        }
-
-        color: BVApp.Theme.highlightDimmerColor
-
-        // relative to parent opacity!
-        opacity: BVApp.Platform.isSailfish ? 0.6 : 1
-        visible: !BVApp.Platform.isSailfish || pictureAvailable
-    }
-
     Label {
         id: streetLabel
         text: street
         font.pixelSize: BVApp.Theme.fontSizeExtraSmall
-        color: BVApp.Platform.isSailfish ? BVApp.Theme.highlightColor : BVApp.Theme.secondaryColor
+        color: BVApp.Theme.highlightColor
         truncationMode: TruncationMode.Fade
 
         anchors {
             left: image.left
             right: distanceLabel.left
-            margins: BVApp.Theme.paddingLarge
+            bottom: parent.bottom
+            leftMargin: BVApp.Theme.paddingLarge // BVApp.Theme.horizontalPageMargin
         }
-
-        y: parent.height - height
     }
 
     Label {
@@ -124,10 +114,9 @@ Item {
 
         anchors {
             right: parent.right
-            margins:  BVApp.Theme.paddingLarge
+            bottom: parent.bottom
+            rightMargin: BVApp.Theme.paddingLarge // BVApp.Theme.horizontalPageMargin
         }
-
-        y: parent.height - height
     }
 }
 

--- a/qml/pages/VenueDescription.qml
+++ b/qml/pages/VenueDescription.qml
@@ -55,13 +55,15 @@ BVApp.Page {
             positionSource: page.positionSource
 
             opacity: flicka.scrolledUpRatio
-            height: page.height / 3
+            height: page.height / 2.7
             shrinkHeightBy: flicka.contentY
 
             anchors {
                 left: parent.left
                 right: parent.right
                 top: parent.top
+
+                bottomMargin: BVApp.Theme.paddingSmall
             }
         }
 
@@ -73,7 +75,11 @@ BVApp.Page {
                 left: parent.left
                 right: parent.right
                 top: locationheader.bottom
-                margins: BVApp.Theme.paddingMedium
+
+                leftMargin: BVApp.Theme.horizontalPageMargin
+                rightMargin: BVApp.Theme.horizontalPageMargin
+                topMargin: BVApp.Theme.paddingSmall
+                bottomMargin: BVApp.Theme.paddingLarge
             }
 
             opacity: flicka.scrolledUpRatio


### PR DESCRIPTION
and distance label in the venue description
with a opacity transition in the venue picture.

Fixes #122 

![variant2_sailfishos](https://user-images.githubusercontent.com/8768660/29048720-66cac3ec-7bd2-11e7-8f1a-9f5f01466936.jpg)

![variant2_vplay](https://user-images.githubusercontent.com/8768660/29048726-6b64916c-7bd2-11e7-9490-f2f42873a2f8.png)
