### PR TITLE
[SailfishOS] Flter out jolla Silica credit

### DIFF
--- a/qml/pages/about/AboutBerlinVegan.qml
+++ b/qml/pages/about/AboutBerlinVegan.qml
@@ -481,6 +481,7 @@ BVApp.Page {
                model: ListModel {
 
                    ListElement {
+                       filterOut: BVApp.Platform.isSailfish
                        name: "Sailfish Silica"
                        url: "https://github.com/dm8tbr/sailfishsilica-qt5"
                        licenseName: "MIT"

--- a/qml/pages/about/ThirdPartySoftware.qml
+++ b/qml/pages/about/ThirdPartySoftware.qml
@@ -34,7 +34,9 @@ SilicaListView {
     delegate: ListItem {
 
         width: parent.width
-        contentHeight: column.height
+        contentHeight: model.filterOut ?
+                         0
+                       : column.height
 
         Column {
             id: column


### PR DESCRIPTION
B/C it doesn't make really sense to include
it again. Plus, the 'license file'

    qrc:/imports/Sailfish/Silica/OpacityRampEffectBase.qml

isn't available on SailfishOS (at least not there),