### PR TITLE
Show "get directions", when coming from map overview

### DIFF
--- a/qml/pages/VenueMapOverviewPage.qml
+++ b/qml/pages/VenueMapOverviewPage.qml
@@ -93,6 +93,16 @@ BVApp.Page {
                                            restaurant     : currRestaurant,
                                            positionSource : page.positionSource
                                        });
+
+                        // The icon parameter is only used on v-play
+                        pageStack.pushAttached(Qt.resolvedUrl("VenueMapPage.qml"),
+                                       {
+                                           venueCoordinate: QtPositioning.coordinate(currRestaurant.latCoord,
+                                                                                     currRestaurant.longCoord),
+                                           positionSource: page.positionSource,
+                                           name: currRestaurant.name
+                                       }, BVApp.Theme.iconFor("locationarrow")
+                                       );
                     }
                 }
             }


### PR DESCRIPTION
Although we stack up the navigation with map views, without this patch a
user has to go back all the stack and select the venue from the list to
get directions in Apple Maps.

Closes #153