### PR TITLE
Display all images in venue description

### DIFF
--- a/qml/components-Sailfish/Theme.qml
+++ b/qml/components-Sailfish/Theme.qml
@@ -78,6 +78,7 @@ QtObject {
     readonly property int fontSizeExtraLarge: Silica.Theme.fontSizeExtraLarge
 
     readonly property int pageIndicatorSmall: Silica.Theme.paddingSmall
+    readonly property int pageIndicatorPadding: 2*Silica.Theme.paddingLarge
     readonly property color pageIndicatorColor: Silica.Theme.highlightColor
 
     readonly property int iconSizeMedium : Silica.Theme.iconSizeMedium

--- a/qml/components-Sailfish/Theme.qml
+++ b/qml/components-Sailfish/Theme.qml
@@ -77,6 +77,9 @@ QtObject {
     readonly property int fontSizeLarge: Silica.Theme.fontSizeLarge
     readonly property int fontSizeExtraLarge: Silica.Theme.fontSizeExtraLarge
 
+    readonly property int pageIndicatorSmall: Silica.Theme.paddingSmall
+    readonly property color pageIndicatorColor: Silica.Theme.highlightColor
+
     readonly property int iconSizeMedium : Silica.Theme.iconSizeMedium
     readonly property int iconSizeLarge : Silica.Theme.iconSizeLarge
 

--- a/qml/components-generic/PageIndicator.qml
+++ b/qml/components-generic/PageIndicator.qml
@@ -1,0 +1,50 @@
+/**
+ *
+ *  This file is part of the Berlin-Vegan guide (SailfishOS app version),
+ *  Copyright 2015-2016 (c) by micu <micuintus.de> (micuintus@gmx.de).
+ *
+ *      <https://github.com/micuintus/harbour-Berlin-vegan>.
+ *
+ *  The Berlin-Vegan guide is Free Software:
+ *  you can redistribute it and/or modify it under the terms of the
+ *  GNU General Public License as published by the Free Software Foundation,
+ *  either version 2 of the License, or (at your option) any later version.
+ *
+ *  Berlin-Vegan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with The Berlin Vegan Guide.
+ *
+ *  If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>.
+ *
+**/
+
+import QtQuick 2.2
+
+import BerlinVegan.components.platform 1.0 as BVApp
+
+// We cannot use upstream implementation, because SailfishOS does not support
+// Qt Quick Controls 2 at the moment (see SwipeView.qml)
+ListView {
+    id: root
+
+    width: contentItem.width
+    height: BVApp.Theme.pageIndicatorSmall
+
+    spacing: BVApp.Theme.paddingSmall
+    orientation: Qt.Horizontal
+
+    delegate: Rectangle {
+        implicitWidth: BVApp.Theme.pageIndicatorSmall
+        implicitHeight: BVApp.Theme.pageIndicatorSmall
+
+        radius: width / 2
+        color: BVApp.Theme.pageIndicatorColor
+
+        opacity: index === root.currentIndex ? 0.95 : pressed ? 0.7 : 0.45
+        Behavior on opacity { OpacityAnimator { duration: 100 } }
+    }
+}

--- a/qml/components-generic/SwipeView.qml
+++ b/qml/components-generic/SwipeView.qml
@@ -1,0 +1,51 @@
+/**
+ *
+ *  This file is part of the Berlin-Vegan guide (SailfishOS app version),
+ *  Copyright 2015-2016 (c) by micu <micuintus.de> (micuintus@gmx.de).
+ *
+ *      <https://github.com/micuintus/harbour-Berlin-vegan>.
+ *
+ *  The Berlin-Vegan guide is Free Software:
+ *  you can redistribute it and/or modify it under the terms of the
+ *  GNU General Public License as published by the Free Software Foundation,
+ *  either version 2 of the License, or (at your option) any later version.
+ *
+ *  Berlin-Vegan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with The Berlin Vegan Guide.
+ *
+ *  If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>.
+ *
+**/
+
+import QtQuick 2.2
+
+// We cannot use upstream implementation, because SailfishOS does not support
+// Qt Quick Controls 2 at the moment (see PageIndicator.qml)
+ListView {
+    interactive: true
+    currentIndex: 0
+
+    spacing: 0
+    orientation: Qt.Horizontal
+    snapMode: ListView.SnapOneItem
+    boundsBehavior: Flickable.StopAtBounds
+
+    highlightRangeMode: ListView.StrictlyEnforceRange
+    preferredHighlightBegin: 0
+    preferredHighlightEnd: 0
+    highlightMoveDuration: 250
+
+    // This number needs to be pretty high, otherwise the image components are destroyed and recreated all the time,
+    // which would lead to white spaces during fast scrolling. This can be checked by putting:
+    //
+    //  Component.onCompleted: console.log("created:", index)
+    //  Component.onDestruction: console.log("destroyed:", index)
+    //
+    // into the delegate component.
+    cacheBuffer: 9999
+}

--- a/qml/components-generic/VenueDescriptionHeader.qml
+++ b/qml/components-generic/VenueDescriptionHeader.qml
@@ -36,6 +36,8 @@ import "tinycolor.js" as TinyColor
 
 Item {
 
+    id: root
+
     property string name
     property string street
     property var restaurantCoordinate
@@ -46,31 +48,48 @@ Item {
     property real shrinkHeightBy
 
 
-    Image {
-        id: image
+    BVApp.SwipeView {
+        id: images
 
-        source: pictureAvailable
-                ? pictures[0].url
-                : "qrc:/images/Platzhalter_v2_mitSchriftzug" + (BVApp.Platform.isSailfish ?
-                                                                  "_alpha.png"
-                                                                : ".jpg")
-        fillMode: Image.PreserveAspectCrop
+        anchors.fill: parent
 
-        visible: pictureAvailable || BVApp.Platform.isVPlay
+        // '1' so we see the placeholder image
+        model: pictures.length ? pictures.length : 1
 
-        height: Math.max(parent.height - shrinkHeightBy,0)
-        width: parent.width
+        delegate: Image {
 
-        // This leads to the effect that the image is being cropped
-        // from both bottom and top by half a pixel per shrinkHeightBy
-        y: shrinkHeightBy
+            source: pictureAvailable
+                    ? pictures[index].url
+                    : "qrc:/images/Platzhalter_v2_mitSchriftzug" + (BVApp.Platform.isSailfish ?
+                                                                        "_alpha.png"
+                                                                      : ".jpg")
+            fillMode: Image.PreserveAspectCrop
+
+            height: Math.max(root.height - shrinkHeightBy,0)
+            width: root.width
+
+            // This leads to the effect that the image is being cropped
+            // from both bottom and top by half a pixel per shrinkHeightBy
+            y: shrinkHeightBy
+        }
+    }
+
+    BVApp.PageIndicator {
+        visible: images.count > 1
+
+        model: images.count
+        currentIndex: images.currentIndex
+
+        anchors.bottom: images.bottom
+        anchors.bottomMargin: BVApp.Theme.pageIndicatorPadding
+        anchors.horizontalCenter: parent.horizontalCenter
     }
 
     OpacityRampEffect {
         id: ramp
         enabled: BVApp.Platform.isSailfish
-        anchors.fill: image
-        sourceItem: image
+        anchors.fill: images
+        sourceItem: images
         direction: BVApp.Theme.opacityRampTopToBottom
         offset: 0.54
         slope: 2.24
@@ -81,7 +100,7 @@ Item {
         hue: TinyColor.rgbToHsl(srcColor.r, srcColor.g, srcColor.b).h
         source: ramp
         visible: !pictureAvailable && BVApp.Platform.isSailfish
-        anchors.fill: image
+        anchors.fill: images
         cached: true
     }
 

--- a/qml/components-generic/qmldir
+++ b/qml/components-generic/qmldir
@@ -9,3 +9,5 @@ Database 1.0 Database.js
 DistanceAlgorithms 1.0 distance.js
 OpeningHoursModelAlgorithms 1.0 OpeningHoursModelAlgorithms.js
 VenueDescriptionAlgorithms 1.0 VenueDescriptionAlgorithms.js
+SwipeView 1.0 SwipeView.qml
+PageIndicator 1.0 PageIndicator.qml

--- a/qml/components-generic/resources-components-generic.qrc
+++ b/qml/components-generic/resources-components-generic.qrc
@@ -12,5 +12,7 @@
         <file>VenueDescriptionHeader.qml</file>
         <file>VenueDetails.qml</file>
         <file>tinycolor.js</file>
+        <file>SwipeView.qml</file>
+        <file>PageIndicator.qml</file>
     </qresource>
 </RCC>

--- a/qml/components-v-play/Theme.qml
+++ b/qml/components-v-play/Theme.qml
@@ -110,6 +110,7 @@ QtObject {
     readonly property int fontSizeExtraLarge: dp(23)
 
     readonly property int pageIndicatorSmall: dp(6)
+    readonly property int pageIndicatorPadding: dp(6)
     readonly property color pageIndicatorColor: "white"
 
     // HACK: only used in IconToolBar so far, we want to keep scale at 1 ATM

--- a/qml/components-v-play/Theme.qml
+++ b/qml/components-v-play/Theme.qml
@@ -109,6 +109,8 @@ QtObject {
     readonly property int fontSizeLarge: dp(18)
     readonly property int fontSizeExtraLarge: dp(23)
 
+    readonly property int pageIndicatorSmall: dp(6)
+    readonly property color pageIndicatorColor: "white"
 
     // HACK: only used in IconToolBar so far, we want to keep scale at 1 ATM
     readonly property int iconSizeMedium: dp(26)


### PR DESCRIPTION
Often we have more than one image for a venue. To display them all we
use a SwipeView and a PageIndicator to show the user, that he/she can
swipe through the images.

Note: we cannot use upstream implementation, because SailfishOS does not
support Qt Quick Controls 2 at the moment.

Closes #1