### PR TITLE
[sfos] Fix BusyIndicator is shown all the time

### DIFF
--- a/qml/harbour-berlin-vegan.qml
+++ b/qml/harbour-berlin-vegan.qml
@@ -115,7 +115,7 @@ ApplicationWindow
             id: venueList
             positionSource: globalPositionSource
             jsonModelCollection: gJsonCollection
-            currentCategoryLoaded: function () {
+            currentCategoryLoaded: {
                 return gJsonVenueModel.loadedVenueType & gJsonCollection.filterVenueType;
             }
             onSearchStringChanged: {


### PR DESCRIPTION
Currently the BusyIndicator works on V-Play as expected: It is shown,
when the list is not loaded yet and it is hidden otherwise.

On SailfishOS the BusyIndicator is shown all the time. The patch fixes
this issue.

Closes #143