### PR TITLE
Fix #143 --- without breaking #141 again

### DIFF
--- a/qml/components-Sailfish/MenuItem.qml
+++ b/qml/components-Sailfish/MenuItem.qml
@@ -2,8 +2,10 @@ import Sailfish.Silica 1.0 as Silica
 import QtQuick 2.2
 
 Silica.MenuItem {
-    property var page
+    property Page page
+    property Component pageComponent
+
     property var menuIcon
 
-    onClicked: pageStack.push(page)
+    onClicked: page = pageStack.push(pageComponent)
 }

--- a/qml/components-v-play/ActionMenuItem.qml
+++ b/qml/components-v-play/ActionMenuItem.qml
@@ -3,13 +3,6 @@ import VPlayApps 1.0
 import BerlinVegan.components.platform 1.0 as BVApp
 
 BVApp.MenuItem {
-    property Component pageComponent
-    onPageComponentChanged:
-    {
-        page = pageComponent.createObject()
-    }
-
     signal clicked
-
     onSelected: clicked()
 }

--- a/qml/components-v-play/MenuItem.qml
+++ b/qml/components-v-play/MenuItem.qml
@@ -4,9 +4,10 @@ import BerlinVegan.components.platform 1.0 as BVApp
 
 NavigationItem {
     id: item
-    property var page
     property var menuIcon
     property alias text: item.title
+    property Component pageComponent
+    property Page page
 
     icon: menuIcon.iconString
 
@@ -15,9 +16,17 @@ NavigationItem {
     }
 
     BVApp.NavigationStackWithPushAttached
+    {  }
+
+    onLoaded:
     {
-        initialPage: page
+        if (pageComponent)
+        {
+            navigationStack.push(pageComponent);
+            page = navigationStack.getPage(0);
+        }
     }
+
 
     onSelected: {
         navigationStack.popAllExceptFirst()

--- a/qml/harbour-berlin-vegan.qml
+++ b/qml/harbour-berlin-vegan.qml
@@ -115,9 +115,7 @@ ApplicationWindow
             id: venueList
             positionSource: globalPositionSource
             jsonModelCollection: gJsonCollection
-            currentCategoryLoaded: function () {
-                return gJsonVenueModel.loadedVenueType & gJsonCollection.filterVenueType;
-            }
+            currentCategoryLoaded: gJsonVenueModel.loadedVenueType & gJsonCollection.filterVenueType;
             onSearchStringChanged: {
                 gJsonCollection.searchString = searchString
             }
@@ -173,7 +171,7 @@ ApplicationWindow
             menuIcon: BVApp.Theme.iconFor("filter")
             //% "Filter"
             text: qsTrId("id-filter")
-            page: VenueFilterSettings {
+            pageComponent: VenueFilterSettings {
                 jsonModelCollection: gJsonCollection
             }
         }
@@ -183,7 +181,7 @@ ApplicationWindow
             //% "About"
             text: qsTrId("id-about-venue-list")
 
-            page: AboutBerlinVegan { }
+            pageComponent: AboutBerlinVegan { }
         }
     }
 }


### PR DESCRIPTION
Shortened explanation:

NavigationItem is derived from Tab

    <https://v-play.net/doc/vplayapps-navigationitem/>

and Tabs are lazily loaded
(if the 'active' property isn't true on start).

FYI: Tabs are derived from Loader and the loading happens here:
<https://code.woboq.org/qt5/qtdeclarative/src/quick/items/qquickloader.cpp.html#597>.

Tabs being lazily loaded doesn't cause any problems per se,
but we did create the actual page to be shown in ActionMenuItem
(in our case, this page was VenueList.qml) immediately. Now this page
already existed, but not its surrounding navigation stack, etc.

Only when the surrounding menu item is being (by clicking on it),
all the signal connections are being set up correctly.