### PR TITLE
Fix #166: Go back to original zoom level

### DIFF
--- a/qml/pages/VenueMapOverviewPage.qml
+++ b/qml/pages/VenueMapOverviewPage.qml
@@ -113,6 +113,6 @@ BVApp.Page {
             center = currentPosition.coordinate
         }
 
-        zoomLevel: maximumZoomLevel - 9
+        zoomLevel: maximumZoomLevel - (BVApp.Platform.isSailfish ? 3 : 9)
     }
 }


### PR DESCRIPTION
on Sailfish for Map Overview. Somehow the values
seem to differ on SailfishOS and V-Play / Mapbox.