### PR TITLE
Remove last traces of Cutehacks::gel

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rdparty/Cutehacks/gel"]
-	path = 3rdparty/Cutehacks/gel
-	url = git@github.com:micuintus/gel.git

--- a/BerlinVegan.pro
+++ b/BerlinVegan.pro
@@ -15,8 +15,7 @@ SOURCES += src/BerlinVegan.cpp \
 
 HEADERS += src/VenueModel.h \
            src/VenueSortFilterProxyModel.h \
-           src/TruncationMode.h \
-           3rdparty/Cutehacks/gel/jsvalueiterator.h
+           src/TruncationMode.h
 
 RESOURCES += resources.qrc \
              qml/components-generic/resources-components-generic.qrc

--- a/qml/components-Sailfish/Theme.qml
+++ b/qml/components-Sailfish/Theme.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 
-import harbour.berlin.vegan.gel 1.0
+import harbour.berlin.vegan 1.0
 import Sailfish.Silica 1.0 as Silica
 import QtQuick 2.2
 

--- a/qml/components-generic/IconToolBar.qml
+++ b/qml/components-generic/IconToolBar.qml
@@ -27,7 +27,7 @@ import QtQuick.Layouts 1.1
 import Sailfish.Silica 1.0
 import BerlinVegan.components.platform 1.0 as BVApp
 import BerlinVegan.components.generic 1.0 as BVApp
-import harbour.berlin.vegan.gel 1.0
+import harbour.berlin.vegan 1.0
 
 Column {
     property var restaurant

--- a/qml/components-generic/VenueDescriptionAlgorithms.js
+++ b/qml/components-generic/VenueDescriptionAlgorithms.js
@@ -23,7 +23,7 @@
 **/
 
 .pragma library
-.import harbour.berlin.vegan.gel 1.0 as BVApp
+.import harbour.berlin.vegan 1.0 as BVApp
 
 
 function defaultBooleanProperty(key)

--- a/qml/components-v-play/Theme.qml
+++ b/qml/components-v-play/Theme.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 
-import harbour.berlin.vegan.gel 1.0
+import harbour.berlin.vegan 1.0
 import QtQuick 2.7
 import VPlayApps 1.0
 

--- a/qml/harbour-berlin-vegan.qml
+++ b/qml/harbour-berlin-vegan.qml
@@ -25,7 +25,7 @@
 import QtQuick 2.2
 import Sailfish.Silica 1.0
 import QtPositioning 5.2
-import harbour.berlin.vegan.gel 1.0
+import harbour.berlin.vegan 1.0
 import BerlinVegan.components.platform 1.0 as BVApp
 import BerlinVegan.components.generic 1.0 as BVApp
 

--- a/qml/pages/VenueFilterSettings.qml
+++ b/qml/pages/VenueFilterSettings.qml
@@ -24,7 +24,7 @@
 
 import QtQuick 2.2
 import Sailfish.Silica 1.0
-import harbour.berlin.vegan.gel 1.0
+import harbour.berlin.vegan 1.0
 import BerlinVegan.components.platform 1.0 as BVApp
 import BerlinVegan.components.generic 1.0 as BVApp
 

--- a/qml/pages/VenueList.qml
+++ b/qml/pages/VenueList.qml
@@ -31,7 +31,7 @@ import BerlinVegan.components.generic 1.0 as BVApp
 
 import "."
 
-import harbour.berlin.vegan.gel 1.0
+import harbour.berlin.vegan 1.0
 
 BVApp.Page {
 

--- a/src/BerlinVegan.cpp
+++ b/src/BerlinVegan.cpp
@@ -42,8 +42,8 @@
 
 int main(int argc, char *argv[])
 {
-    qmlRegisterType<VenueModel>("harbour.berlin.vegan.gel", 1, 0, "VenueModel");
-    qmlRegisterType<VenueSortFilterProxyModel>("harbour.berlin.vegan.gel", 1, 0, "VenueSortFilterProxyModel");
+    qmlRegisterType<VenueModel>("harbour.berlin.vegan", 1, 0, "VenueModel");
+    qmlRegisterType<VenueSortFilterProxyModel>("harbour.berlin.vegan", 1, 0, "VenueSortFilterProxyModel");
     auto const mainQMLFile = QString("qrc:/qml/harbour-berlin-vegan.qml");
 
 #ifdef Q_OS_SAILFISH

--- a/src/VenueModel.cpp
+++ b/src/VenueModel.cpp
@@ -3,15 +3,9 @@
 #include <QStandardItem>
 #include <QtQml/qqml.h>
 #include <QtQml/QQmlEngine>
+#include <QtQml/QJSValueIterator>
 #include <iostream>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
-#include <3rdparty/Cutehacks/gel/jsvalueiterator.h>
-using namespace com::cutehacks::gel;
-#else
-#include <QtQml/QJSValueIterator>
-typedef QJSValueIterator JSValueIterator;
-#endif
 
 VenueModel::VenueModel(QObject *parent) :
     QStandardItemModel(parent)
@@ -41,7 +35,7 @@ void VenueModel::importFromJson(const QJSValue &item, VenueType venueType)
 {
     if (item.isArray()) {
         auto root = this->invisibleRootItem();
-        JSValueIterator array(item);
+        QJSValueIterator array(item);
 
         while (array.next()) {
             if (!array.hasNext())


### PR DESCRIPTION
As nice at it is, with our own C++ model in place,
we don't need Cutehacks' gel anymore. Now that
Sailfish's Qt is finally at least on 5.6,
we can remove gel completely, as we can use QJSValueIterator
on Sailfish, as well.