### PR TITLE
Fix: placeholder image sometime not shown

### DIFF
--- a/qml/components-generic/VenueDescriptionHeader.qml
+++ b/qml/components-generic/VenueDescriptionHeader.qml
@@ -54,7 +54,7 @@ Item {
         anchors.fill: parent
 
         // '1' so we see the placeholder image
-        model: pictures.length ? pictures.length : 1
+        model: pictureAvailable ? pictures.length : 1
 
         delegate: Image {
 


### PR DESCRIPTION
Due to the error below, the if condition can not be evaluated and
therefore model is not set to '1'.

Error:
* VenueDescriptionHeader.qml:57: TypeError: Cannot read property
  'length' of undefined