### PR TITLE
[v-play] Fix location marker's color

### DIFF
--- a/qml/pages/VenueMapOverviewPage.qml
+++ b/qml/pages/VenueMapOverviewPage.qml
@@ -100,6 +100,7 @@ BVApp.Page {
                                            venueCoordinate: QtPositioning.coordinate(currRestaurant.latCoord,
                                                                                      currRestaurant.longCoord),
                                            positionSource: page.positionSource,
+                                           vegan: currRestaurant.vegan,
                                            name: currRestaurant.name
                                        }, BVApp.Theme.iconFor("locationarrow")
                                        );


### PR DESCRIPTION
When coming from VenueMapOverviewPage location marker's color is always
red, instead of green for e.g. vegan venues.

We forgot to forward the information (in VenueList.qml, we are doing it
correctly already).

Closes #183