### PR TITLE
Fix #185 Don't reevaluate currRestaurant onClicked

### DIFF
--- a/qml/pages/VenueMapOverviewPage.qml
+++ b/qml/pages/VenueMapOverviewPage.qml
@@ -87,7 +87,6 @@ BVApp.Page {
                     verticalAlignment: Text.AlignBottom
 
                     onClicked: {
-                        var currRestaurant = mapItemView.model.item(index);
                         pageStack.push(Qt.resolvedUrl("VenueDescription.qml"),
                                        {
                                            restaurant     : currRestaurant,


### PR DESCRIPTION
It could result in a different venue if the sorting has changed in the
meantime.

TODO: Refactor restaurant handover in way that it isn't longer based on
those colum indices.