### PR TITLE
[ios] Fix broken font after V-Play 2.15.1 update

### DIFF
--- a/qml/Silica4v-play/Text.qml
+++ b/qml/Silica4v-play/Text.qml
@@ -1,0 +1,35 @@
+/**
+ *
+ *  This file is part of the Berlin-Vegan guide (SailfishOS app version),
+ *  Copyright 2015-2018 (c) by micu <micuintus.de> (post@micuintus.de).
+ *  Copyright 2017-2018 (c) by jmastr <veggi.es> (julian@veggi.es).
+ *
+ *      <https://github.com/micuintus/harbour-Berlin-vegan>.
+ *
+ *  The Berlin-Vegan guide is Free Software:
+ *  you can redistribute it and/or modify it under the terms of the
+ *  GNU General Public License as published by the Free Software Foundation,
+ *  either version 2 of the License, or (at your option) any later version.
+ *
+ *  Berlin-Vegan is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with The Berlin Vegan Guide.
+ *
+ *  If not, see <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>.
+ *
+**/
+
+import QtQuick 2.7
+
+Text {
+
+    // Qt 5.10.1 changed the default font family on iOS changed from ".SF UI Text"
+    // to "System Font Regular" for unknown reasons, which looks really bad.
+    // See: https://github.com/micuintus/harbour-Berlin-Vegan/issues/207
+    font.family: ".SF UI Text"
+
+}

--- a/qml/Silica4v-play/qmldir
+++ b/qml/Silica4v-play/qmldir
@@ -13,5 +13,6 @@ PageHeader 1.0 PageHeader.qml
 Separator 1.0 Separator.qml
 SilicaFlickable 1.0 SilicaFlickable.qml
 SilicaListView 1.0 SilicaListView.qml
+Text 1.0 Text.qml
 TextSwitch 1.0 TextSwitch.qml
 VerticalScrollDecorator 1.0 VerticalScrollDecorator.qml

--- a/qml/Silica4v-play/resources-Silica4v-play.qrc
+++ b/qml/Silica4v-play/resources-Silica4v-play.qrc
@@ -20,6 +20,7 @@
         <file>VerticalScrollDecorator.qml</file>
         <file>Button.qml</file>
         <file>OpacityRampEffectBase.qml</file>
+        <file>Text.qml</file>
         <file>TextSwitch.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
V-Play 2.15.1 ships Qt 5.10.1, which changed the default font family on
iOS changed from ".SF UI Text" to "System Font Regular" for unknown
reasons, which looks really bad.

See:
* https://github.com/micuintus/harbour-Berlin-Vegan/issues/207

Closes #207