### PR TITLE
Open external map when clicking on markers

### DIFF
--- a/qml/pages/VenueMapPage.qml
+++ b/qml/pages/VenueMapPage.qml
@@ -66,17 +66,17 @@ Rectangle {
         }
 
         zoomLevel: maximumZoomLevel - 1
+    }
 
-        MouseArea {
-            anchors.fill: parent
+    MouseArea {
+        anchors.fill: parent
 
-            onClicked: {
-                var query = venueCoordinate.latitude + "," + venueCoordinate.longitude
-                if (BVApp.Platform.isIos || BVApp.Platform.isMacOS) {
-                    Qt.openUrlExternally("https://maps.apple.com/?q=" + query)
-                } else {
-                    Qt.openUrlExternally("geo:" + query)
-                }
+        onClicked: {
+            var query = venueCoordinate.latitude + "," + venueCoordinate.longitude
+            if (BVApp.Platform.isIos || BVApp.Platform.isMacOS) {
+                Qt.openUrlExternally("https://maps.apple.com/?q=" + query)
+            } else {
+                Qt.openUrlExternally("geo:" + query)
             }
         }
     }


### PR DESCRIPTION
The idea is, at least for now, to open the external map app when
clicking anywhere in venue description's map view. This does not work,
especially when clicking on the venue's location marker, which is very
bad UX.

Closes #209