### PR TITLE
Fix: always closed when selecting venue via map

### DIFF
--- a/qml/pages/VenueMapOverviewPage.qml
+++ b/qml/pages/VenueMapOverviewPage.qml
@@ -110,7 +110,7 @@ BVApp.Page {
                     onClicked: {
                         pageStack.push(Qt.resolvedUrl("VenueDescription.qml"),
                                        {
-                                           restaurant     : model,
+                                           restaurant     : page.model.item(index),
                                            positionSource : page.positionSource
                                        });
                     }


### PR DESCRIPTION
Without this patch a venue is always closed from Monday til Sunday when
selecting it via the map overview.

The reason is not completely clear to me, because debugging the problem
showed, that the information is there. The difference is that 'model' is
e.g. 'QObject(0x1261e4140)' and 'page.model.item(index)' is '[object
Object]', like 'jsonModelCollection.item(index)' in VenueList.qml, where
it is known to be working correctly.

Closes #222