### PR TITLE
[ios] Add possibility to choose map app

### DIFF
--- a/qml/pages/VenueMapPage.qml
+++ b/qml/pages/VenueMapPage.qml
@@ -71,11 +71,34 @@ Rectangle {
 
         onClicked: {
             var query = venueCoordinate.latitude + "," + venueCoordinate.longitude
-            if (BVApp.Platform.isIos || BVApp.Platform.isMacOS) {
+            if (BVApp.Platform.isIos) {
+                // displays a modal alert sheet with the specific options. It uses an AlertDialog on Android and a UIActionSheet on iOS.
+                nativeUtils.displayAlertSheet("", ["Apple Maps", "Google Maps"], true);
+            } else if (BVApp.Platform.isMacOS) {
                 Qt.openUrlExternally("https://maps.apple.com/?q=" + query)
             } else {
                 Qt.openUrlExternally("geo:" + query)
             }
+        }
+    }
+
+    // the result of the input dialog is received with a connection to the signal textInputFinished
+    Connections {
+        // supress warning "ReferenceError: nativeUtils is not defined" on SailfishOS by setting target to "null"
+        target: BVApp.Platform.isIos ? nativeUtils : null
+        onAlertSheetFinished: {
+            // cancel was clicked
+            if (index === -1) {
+                return;
+            }
+
+            var url = "apple";
+            if (index === 1) {
+                url = "google";
+            }
+
+            var query = venueCoordinate.latitude + "," + venueCoordinate.longitude
+            nativeUtils.openUrl("https://maps." + url + ".com/?q=" + query);
         }
     }
 }


### PR DESCRIPTION
With this patch a user can choose if he/she wants to open the
destination either with Apple or with Google Maps.

If an app is not installed it will open the link in the browser.

On desktop one does not get a chooser presented. This behaviour is
implemented in NativeUtils.

Note: Currently the strings are hard-coded, because I don't see the
necessity for translating those strings for our supported languages.