### PR TITLE
Fix #286: Enable HDPI scaling & repair navbar size

### DIFF
--- a/qml/components-felgo/NavigationStackWithPushAttached.qml
+++ b/qml/components-felgo/NavigationStackWithPushAttached.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.7
+import QtQuick.Window 2.7
 import Felgo 3.0
 
 import BerlinVegan.components.platform 1.0 as BVApp
@@ -25,5 +26,20 @@ NavigationStack {
         });
 
         stack.currentPage.rightBarItem = attachedButton;
+    }
+
+    Component.onCompleted: {
+        // This hotfixes a faulty navigation bar height on Android after enabling the default Qt high dpi support in main.cpp:
+        if (!BVApp.Platform.isAndroid) {
+            return
+        }
+        // Before the next line "navigationBar.height = 139.97597452201887" on my test device.
+        anchors.topMargin = 1
+        // The line above triggers something so that the "navigationBar.height = 55.97597452201887", but now it is partly hidden
+        // by the status bar on Android, so we add "Theme.statusBarHeight" but taking the high dpi scaling factor into account.
+        navigationBar.height += Theme.statusBarHeight / Screen.devicePixelRatio
+        // Afterwards the "navigationBar.height = 79.96567788859839". Next we reset the anchor again to its default value.
+        anchors.topMargin = 0
+        // As comparison: without high dpi "navigationBar.height = 56" and "Theme.statusBarHeight = 24" on my test device.
     }
 }

--- a/qml/silica4felgo/ApplicationWindow.qml
+++ b/qml/silica4felgo/ApplicationWindow.qml
@@ -1,6 +1,7 @@
 import Felgo 3.0
 
 import QtQuick 2.7
+import QtQuick.Window 2.7
 
 import BerlinVegan.components.platform 1.0 as BVApp
 
@@ -12,6 +13,8 @@ App {
     property Component initialPage
 
     onInitTheme: {
+        // this hotfixes a faulty navbar bar height size after enabling the default Qt high dpi support in main.cpp
+        Theme.navigationBar.height = Theme.navigationBar.height/Screen.devicePixelRatio
         Theme.navigationBar.backgroundColor = BVApp.Theme.highlightColor
         Theme.navigationBar.titleColor = "white"
         // otherwise tintColor is used (see below) and you might have a hard time seeing navigation

--- a/qml/silica4felgo/ApplicationWindow.qml
+++ b/qml/silica4felgo/ApplicationWindow.qml
@@ -1,7 +1,6 @@
 import Felgo 3.0
 
 import QtQuick 2.7
-import QtQuick.Window 2.7
 
 import BerlinVegan.components.platform 1.0 as BVApp
 
@@ -13,8 +12,6 @@ App {
     property Component initialPage
 
     onInitTheme: {
-        // this hotfixes a faulty navbar bar height size after enabling the default Qt high dpi support in main.cpp
-        Theme.navigationBar.height = Theme.navigationBar.height/Screen.devicePixelRatio
         Theme.navigationBar.backgroundColor = BVApp.Theme.highlightColor
         Theme.navigationBar.titleColor = "white"
         // otherwise tintColor is used (see below) and you might have a hard time seeing navigation

--- a/src/BerlinVegan.cpp
+++ b/src/BerlinVegan.cpp
@@ -45,6 +45,7 @@
 
 int main(int argc, char *argv[])
 {
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     qmlRegisterType<VenueModel>("harbour.berlin.vegan", 1, 0, "VenueModel");
     qmlRegisterType<VenueSortFilterProxyModel>("harbour.berlin.vegan", 1, 0, "VenueSortFilterProxyModel");
     qmlRegisterUncreatableType<VenueHandle>("harbour.berlin.vegan", 1, 0, "VenueHandle", "VenueHandle is not createable from QML");


### PR DESCRIPTION
afterwards to also get correct HDPI maps on Android.